### PR TITLE
Add Visualise all-sky dashboard and select-all query

### DIFF
--- a/lenses/templates/lenses/lens_list_query.html
+++ b/lenses/templates/lenses/lens_list_query.html
@@ -35,27 +35,84 @@
 </div>
 
 <script nonce="{{request.csp_nonce}}">
-  var toggle = function(e) {
-    checkboxes = document.getElementsByName('ids');
-    var new_status = e.currentTarget.getAttribute('value');
-    if (new_status == "select") {
-      for (var i = 0; i < checkboxes.length; i++) {
-        checkboxes[i].checked = true;
-      }
-      e.currentTarget.setAttribute('value', 'unselect');
-    } else {
-      for (var i = 0; i < checkboxes.length; i++) {
-        checkboxes[i].checked = false;
-      }
-      e.currentTarget.setAttribute('value', 'select');
-    }
-  }
-  document.getElementById("toggle_all").addEventListener("click", toggle, true);
+  // Ids of every lens matching the current query, across all pages.
+  // null = "select all" is not active (only the visible checkboxes count).
+  var allPagesIds = null;
+  var toggleBtn = document.getElementById("toggle_all");
 
+  var setVisibleChecked = function(checked) {
+    var checkboxes = document.getElementsByName('ids');
+    for (var i = 0; i < checkboxes.length; i++) { checkboxes[i].checked = checked; }
+  };
+
+  var clearAllPages = function() {
+    allPagesIds = null;
+    toggleBtn.setAttribute('value', 'select');
+    toggleBtn.textContent = 'Toggle select all';
+  };
+
+  var toggle = function(e) {
+    var btn = e.currentTarget;
+    if (btn.getAttribute('value') == "select") {
+      // Activate "select all": fetch every matching id across all pages.
+      var form = document.getElementById('lens-query');
+      btn.disabled = true;
+      fetch("{% url 'lenses:lens-query-all-ids' %}", {
+        method: 'POST',
+        body: new FormData(form),
+        headers: {'X-Requested-With': 'XMLHttpRequest'}
+      })
+        .then(function(r) { if (!r.ok) { throw new Error('bad status'); } return r.json(); })
+        .then(function(d) {
+          allPagesIds = d.ids || [];
+          setVisibleChecked(true);
+          btn.setAttribute('value', 'unselect');
+          btn.textContent = 'Unselect all (' + allPagesIds.length + ' across all pages)';
+          btn.disabled = false;
+        })
+        .catch(function() {
+          btn.disabled = false;
+          alert('Could not select all results. Please try again.');
+        });
+    } else {
+      setVisibleChecked(false);
+      clearAllPages();
+    }
+  };
+  toggleBtn.addEventListener("click", toggle, true);
+
+  // If the user hand-edits any checkbox, drop "select all" mode so the
+  // selection reflects exactly what is checked.
+  document.getElementById("exe_summary").addEventListener("change", function(e) {
+    if (allPagesIds !== null && e.target && e.target.name === 'ids') {
+      clearAllPages();
+    }
+  }, false);
+
+  // Before submitting, if "select all" is active, add a hidden ids input for
+  // every off-page lens so the action operates on the whole result set.
+  var injectAllPageIds = function() {
+    var form = document.getElementById('ids-form');
+    var prev = form.querySelectorAll('input.all-page-id');
+    for (var i = 0; i < prev.length; i++) { prev[i].remove(); }
+    if (allPagesIds === null) { return; }
+    var visible = {};
+    var boxes = document.querySelectorAll('#exe_summary input[name="ids"]');
+    for (var j = 0; j < boxes.length; j++) { visible[boxes[j].value] = true; }
+    for (var k = 0; k < allPagesIds.length; k++) {
+      var id = String(allPagesIds[k]);
+      if (!visible[id]) {
+        var inp = document.createElement('input');
+        inp.type = 'hidden'; inp.name = 'ids'; inp.value = id; inp.className = 'all-page-id';
+        form.appendChild(inp);
+      }
+    }
+  };
+  document.getElementById("ids-form").addEventListener("submit", injectAllPageIds, false);
 
   var min_checked = function(e) {
     var checked_boxes = document.querySelectorAll('#exe_summary input[type="checkbox"]:checked');
-    if (checked_boxes.length == 0) {
+    if (checked_boxes.length == 0 && allPagesIds === null) {
       //alert('You must select at least one lens!');
       e.preventDefault();
     }

--- a/lenses/templates/lenses/lens_query.html
+++ b/lenses/templates/lenses/lens_query.html
@@ -726,6 +726,11 @@
       <img src="{% static 'icons/arrow-down-circle-fill.svg' %}">
       Export .json
     </button>
+
+    <button type="submit" form="ids-form" id="visualise" class="jb-submit-button-1" formaction="{% url 'sled_visualise:lens-visualise' %}" formtarget="_blank">
+      <img src="{% static 'icons/eye-fill.svg' %}">
+      Visualise
+    </button>
 </div>
 
 </div>

--- a/lenses/urls.py
+++ b/lenses/urls.py
@@ -8,6 +8,7 @@ urlpatterns = [
     path('',TemplateView.as_view(template_name='lenses/lens_index.html'), name='lens-index'),
     path('export/',views.ExportToCSV.as_view(),name='export-csv'),
     path('query/',views.LensQueryView.as_view(),name='lens-query'),
+    path('query-all-ids/',views.query_all_ids,name='lens-query-all-ids'),
     path('add/',views.LensAddView.as_view(),name='lens-add'),
     path('update/',views.LensUpdateView.as_view(),name='lens-update'),
     path('update-modal/<int:pk>',views.LensUpdateModalView.as_view(),name='lens-update-modal'),

--- a/lenses/views.py
+++ b/lenses/views.py
@@ -973,8 +973,6 @@ class LensCollageView(ListView):
         return TemplateResponse(request,'simple_message.html',context={'message':'You are accessing this page in an unauthorized way.'})
 
 
-
-
 # View for lens queries
 @method_decorator(login_required,name='dispatch')
 class LensQueryView(TemplateView):
@@ -1054,9 +1052,32 @@ class LensQueryView(TemplateView):
         context = self.my_response(merged_request,request.user)
 
         return self.render_to_response(context)
-        
 
-        
+
+@login_required
+def query_all_ids(request):
+    """Return the ids of every accessible lens matching the posted query form,
+    across all pages. Used by the 'select all' button on the query page so that
+    actions can operate on the entire result set rather than the current page."""
+    if request.method != 'POST':
+        return JsonResponse({'ids': [], 'count': 0, 'error': 'POST required'}, status=400)
+    user = request.user
+    data = request.POST
+    lens_form = forms.LensQueryForm(data, prefix="lens")
+    redshift_form = forms.RedshiftQueryForm(data, prefix="redshift")
+    imaging_form = forms.ImagingQueryForm(data, prefix="imaging")
+    spectrum_form = forms.SpectrumQueryForm(data, prefix="spectrum")
+    catalogue_form = forms.CatalogueQueryForm(data, prefix="catalogue")
+    management_form = forms.ManagementQueryForm(data, prefix="management", user=user)
+    all_forms = [lens_form, redshift_form, imaging_form, spectrum_form, catalogue_form, management_form]
+    if not all(f.is_valid() for f in all_forms):
+        return JsonResponse({'ids': [], 'count': 0, 'error': 'Invalid query parameters'}, status=400)
+    qset = query_utils.combined_query(lens_form.cleaned_data, redshift_form.cleaned_data, imaging_form.cleaned_data,
+                                      spectrum_form.cleaned_data, catalogue_form.cleaned_data, management_form.cleaned_data, user)
+    ids = list(qset.values_list('id', flat=True).distinct())
+    return JsonResponse({'ids': ids, 'count': len(ids)})
+
+
 #=============================================================================================================================
 ### END: Non-modal views
 #=============================================================================================================================

--- a/mysite/settings_common.py
+++ b/mysite/settings_common.py
@@ -60,6 +60,7 @@ INSTALLED_APPS = [
     'sled_limits',
     'sled_guide',
     'sled_lens_models',
+    'sled_visualise',
     'lenses.apps.LensesConfig',
     'sled_groups.apps.GroupsConfig',
     'sled_home.apps.HomeConfig',

--- a/mysite/urls.py
+++ b/mysite/urls.py
@@ -66,6 +66,7 @@ urlpatterns = [
     path('captcha/', include('captcha.urls')),
     path('sled_guide/', include('sled_guide.urls'),name='sled_guide'),
     path('sled_lens_models/', include('sled_lens_models.urls'), name='sled_lens_models'),
+    path('sled_visualise/', include('sled_visualise.urls'), name='sled_visualise'),
 #    path('sled_core/', include('sled_core.urls'), name='sled_core'),
 ]
 

--- a/run_dev_server/settings_development.py
+++ b/run_dev_server/settings_development.py
@@ -36,3 +36,8 @@ CSP_FONT_SRC.append('http://fonts.gstatic.com')
 
 CELERY_BROKER_URL = 'redis://redis:6379'
 CELERY_RESULT_BACKEND = 'redis://redis:6379'
+
+# django-axes: relax login lockout for local development
+AXES_COOLOFF_TIME = 0.25      # auto-unlock after 15 minutes
+AXES_FAILURE_LIMIT = 10       # allow more attempts before locking
+AXES_RESET_ON_SUCCESS = True  # clear the counter on a successful login

--- a/sled_visualise/admin.py
+++ b/sled_visualise/admin.py
@@ -1,0 +1,3 @@
+from django.contrib import admin
+
+# No models to register.

--- a/sled_visualise/apps.py
+++ b/sled_visualise/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class SledVisualiseConfig(AppConfig):
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'sled_visualise'

--- a/sled_visualise/models.py
+++ b/sled_visualise/models.py
@@ -1,0 +1,3 @@
+from django.db import models
+
+# The visualise app has no models of its own; it reads from the lenses app.

--- a/sled_visualise/static/sled_visualise/css/lens_visualise.css
+++ b/sled_visualise/static/sled_visualise/css/lens_visualise.css
@@ -1,0 +1,519 @@
+/* SLED dashboard theme: light page chrome matching the main SLED site
+   (basic-sans / Adobe Typekit, #EFEFEF background, #6F73DD brand purple).
+   The sky-map canvas is also light (white plot area with a thin outline),
+   matching the redshift plot and the rest of the page. */
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: 'basic-sans', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    background: #EFEFEF;
+    color: #1a1a1a;
+    overflow: hidden;
+}
+
+#container {
+    width: 100vw;
+    height: 100vh;
+    display: flex;
+    flex-direction: column;
+}
+
+#header {
+    padding: 14px 20px;
+    background: #ffffff;
+    border-bottom: 3px solid #6F73DD;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.08);
+    display: flex;
+    align-items: center;
+    gap: 18px;
+}
+
+.sled-logo {
+    height: 46px;
+    width: auto;
+}
+
+#header h1 {
+    font-size: 24px;
+    color: #1a1a1a;
+    font-weight: 600;
+    margin-bottom: 2px;
+}
+
+#header p {
+    font-size: 13px;
+    color: #666;
+}
+
+#controls {
+    padding: 12px 20px;
+    background: #ffffff;
+    display: flex;
+    gap: 20px;
+    align-items: center;
+    flex-wrap: wrap;
+    border-bottom: 1px solid #dcdce4;
+}
+
+.control-group {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.control-group label {
+    font-size: 13px;
+    color: #555;
+    font-weight: 500;
+}
+
+select, input[type="range"] {
+    background: #ffffff;
+    color: #1a1a1a;
+    border: 1px solid #b9b9c8;
+    padding: 6px 12px;
+    border-radius: 6px;
+    font-size: 13px;
+}
+
+input[type="range"] {
+    width: 150px;
+    accent-color: #6F73DD;
+}
+
+.ctrl-toggle-btn {
+    background: #ffffff;
+    color: #333;
+    border: 1px solid #b9b9c8;
+    padding: 6px 14px;
+    border-radius: 12px;
+    font-size: 12px;
+    cursor: pointer;
+}
+
+.ctrl-toggle-btn:hover {
+    background: #f0f0f8;
+}
+
+.ctrl-toggle-btn.active {
+    background: #6F73DD;
+    color: #ffffff;
+    border-color: #6F73DD;
+}
+
+.overlay-toggle {
+    display: inline-flex;
+    align-items: center;
+}
+
+.ov-dot {
+    display: inline-block;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    margin-right: 6px;
+}
+
+.ov-des { background: #FF7B00; }
+.ov-sdss { background: #F2C200; }
+.ov-euclid { background: #B26CFF; }
+.ov-galactic { background: #FF4DA6; }
+
+canvas {
+    display: block;
+    cursor: grab;
+}
+
+canvas:active {
+    cursor: grabbing;
+}
+
+#tooltip {
+    position: fixed;
+    background: #ffffff;
+    color: #1a1a1a;
+    padding: 15px;
+    border-radius: 8px;
+    pointer-events: auto;
+    display: none;
+    max-width: 400px;
+    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.25);
+    border: 1px solid #d6d6e0;
+    z-index: 1000;
+}
+
+#tooltip.pinned {
+    border: 2px solid #6F73DD;
+}
+
+#tooltip .close-btn {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    background: #6F73DD;
+    color: #fff;
+    border: none;
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    cursor: pointer;
+    font-size: 16px;
+    line-height: 1;
+    display: none;
+}
+
+#tooltip.pinned .close-btn {
+    display: block;
+}
+
+#tooltip .close-btn:hover {
+    background: #5a5ec9;
+}
+
+#tooltip h3 {
+    margin: 0 0 10px 0;
+    color: #6F73DD;
+    font-size: 16px;
+    border-bottom: 1px solid #e2e2ea;
+    padding-bottom: 8px;
+}
+
+#tooltip .info-row {
+    margin: 6px 0;
+    font-size: 13px;
+    display: grid;
+    grid-template-columns: 120px 1fr;
+    gap: 10px;
+}
+
+#tooltip .info-label {
+    color: #888;
+    font-weight: 500;
+}
+
+#tooltip .info-value {
+    color: #1a1a1a;
+}
+
+#tooltip a {
+    color: #6F73DD;
+    text-decoration: none;
+    transition: color 0.2s;
+}
+
+#tooltip a:hover {
+    color: #4a4ea8;
+    text-decoration: underline;
+}
+
+#loading {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    text-align: center;
+    color: #666;
+    font-size: 18px;
+}
+
+.spinner {
+    border: 4px solid rgba(111, 115, 221, 0.2);
+    border-top: 4px solid #6F73DD;
+    border-radius: 50%;
+    width: 50px;
+    height: 50px;
+    animation: spin 1s linear infinite;
+    margin: 0 auto 15px;
+}
+
+@keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+}
+
+#stats {
+    position: absolute;
+    bottom: 20px;
+    left: 20px;
+    background: rgba(255, 255, 255, 0.92);
+    padding: 10px 14px;
+    border-radius: 6px;
+    font-size: 13px;
+    color: #333;
+    border: 1px solid #c7c7d4;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.25);
+}
+
+.reset-zoom-btn {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    background: #6F73DD;
+    color: #fff;
+    border: none;
+    padding: 4px 8px;
+    border-radius: 6px;
+    font-size: 10px;
+    cursor: pointer;
+    z-index: 10;
+}
+
+.reset-zoom-btn:hover {
+    background: #5a5ec9;
+}
+
+#colorbar {
+    background: transparent;
+    padding: 0;
+    border: none;
+    min-width: auto;
+}
+
+#instructions {
+    position: absolute;
+    top: 45px;
+    right: 15px;
+    background: #ffffff;
+    padding: 20px;
+    border-radius: 8px;
+    border: 1px solid #d6d6e0;
+    max-width: 300px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+    z-index: 100;
+}
+
+#instructions h3 {
+    margin: 0 0 15px 0;
+    font-size: 16px;
+    color: #6F73DD;
+    border-bottom: 1px solid #e2e2ea;
+    padding-bottom: 8px;
+}
+
+#instructions .instr-subhead {
+    color: #4a4ea8;
+    font-size: 13px;
+    margin: 12px 0 8px 0;
+}
+
+#instructions ul {
+    margin: 0;
+    padding-left: 20px;
+    list-style-type: none;
+}
+
+#instructions li {
+    margin: 10px 0;
+    font-size: 13px;
+    color: #444;
+    line-height: 1.5;
+    position: relative;
+}
+
+#instructions li:before {
+    content: "▸";
+    color: #6F73DD;
+    position: absolute;
+    left: -15px;
+}
+
+#instructions .toggle-btn {
+    position: absolute;
+    top: 15px;
+    right: 15px;
+    background: #6F73DD;
+    color: #fff;
+    border: none;
+    width: 28px;
+    height: 28px;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 18px;
+    line-height: 1;
+}
+
+#instructions .toggle-btn:hover {
+    background: #5a5ec9;
+}
+
+#instructions.collapsed {
+    padding: 15px;
+}
+
+#instructions.collapsed h3,
+#instructions.collapsed h4,
+#instructions.collapsed ul {
+    display: none;
+}
+
+#instructions.collapsed .toggle-btn {
+    position: static;
+}
+
+#colorbar h4 {
+    margin: 0 0 10px 0;
+    font-size: 13px;
+    color: #6F73DD;
+    font-weight: 600;
+}
+
+#colorbar .legend-hint {
+    font-size: 10px;
+    color: #999;
+    font-weight: 400;
+}
+
+.legend-list {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    max-height: 70vh;
+    overflow-y: auto;
+}
+
+.legend-item {
+    display: flex;
+    align-items: center;
+    margin: 6px 0;
+    font-size: 12px;
+    color: #333;
+    cursor: pointer;
+    padding: 4px 8px;
+    border-radius: 4px;
+    transition: background-color 0.2s;
+}
+
+.legend-item:hover {
+    background-color: rgba(111, 115, 221, 0.12);
+}
+
+.legend-item.active {
+    background-color: rgba(111, 115, 221, 0.2);
+    border: 1px solid #6F73DD;
+}
+
+.legend-item canvas {
+    border: 1px solid #c7c7d4;
+    border-radius: 4px;
+}
+
+.legend-item .legend-label {
+    margin-left: 12px;
+}
+
+.legend-gradient {
+    height: 20px;
+    border-radius: 4px;
+    margin: 8px 0;
+    border: 1px solid #c7c7d4;
+    background: linear-gradient(to right,
+        hsl(240, 70%, 60%),
+        hsl(180, 70%, 60%),
+        hsl(120, 70%, 60%),
+        hsl(60, 70%, 60%),
+        hsl(0, 70%, 60%));
+}
+
+.legend-labels {
+    display: flex;
+    justify-content: space-between;
+    font-size: 11px;
+    color: #888;
+    margin-top: 4px;
+}
+
+.charts-container {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(300px, 420px);
+    grid-template-rows: 1fr;
+    gap: 10px;
+    flex: 1;
+    padding: 10px;
+    overflow: hidden;
+    min-height: 0;
+}
+
+.chart-panel {
+    background: #ffffff;
+    border: 1px solid #d6d6e0;
+    border-radius: 6px;
+    padding: 15px;
+    padding-bottom: 30px;
+    position: relative;
+    overflow: hidden;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+}
+
+.chart-panel canvas {
+    flex: 1;
+    min-height: 0;
+}
+
+.chart-panel.skymap-large {
+    grid-column: 1;
+}
+
+.info-column {
+    grid-column: 2;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    overflow-y: auto;
+    min-height: 0;
+}
+
+.chart-panel.redshift-panel {
+    flex: 0 0 340px;
+}
+
+/* Narrow windows: stack the sky map full-width on top so it never collapses,
+   with the redshift plot and legend sharing the row below. */
+@media (max-width: 1100px) {
+    .charts-container {
+        grid-template-columns: 1fr;
+        grid-template-rows: minmax(0, 1.6fr) minmax(0, 1fr);
+    }
+    .chart-panel.skymap-large {
+        grid-column: 1;
+        grid-row: 1;
+    }
+    .info-column {
+        grid-column: 1;
+        grid-row: 2;
+        flex-direction: row;
+        overflow: hidden;
+    }
+    .chart-panel.redshift-panel {
+        flex: 1 1 0;
+        min-width: 0;
+    }
+    .info-panel {
+        flex: 1 1 0;
+        min-width: 0;
+        overflow-y: auto;
+    }
+}
+
+.info-panel {
+    background: #ffffff;
+    border: 1px solid #d6d6e0;
+    border-radius: 6px;
+    padding: 15px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+}
+
+.chart-title {
+    color: #6F73DD;
+    font-size: 14px;
+    font-weight: bold;
+    margin-bottom: 10px;
+    text-align: center;
+    flex-shrink: 0;
+}

--- a/sled_visualise/static/sled_visualise/footprints/_coords.js
+++ b/sled_visualise/static/sled_visualise/footprints/_coords.js
@@ -1,0 +1,84 @@
+// Shared coordinate transforms and the survey-footprint registry.
+//
+// Loaded before the per-survey footprint files (des.js, sdss.js, ...) and before
+// lens_visualise.js. Each survey file self-registers into SURVEY_FOOTPRINTS as
+//   SURVEY_FOOTPRINTS.<key> = { color, style, build }
+// where build() returns an array of [RA, Dec] loops (a null entry marks an
+// intentional gap). lens_visualise.js iterates the registry to build and draw the
+// overlays. All transforms are J2000 and numerically verified.
+window.SURVEY_FOOTPRINTS = window.SURVEY_FOOTPRINTS || {};
+
+const ECL_OBLIQUITY = 23.43928;
+
+// Galactic (l, b) deg -> equatorial (RA, Dec) deg.
+function gal2equ(l, b) {
+    const d2r = Math.PI / 180;
+    const aGP = 192.85948 * d2r, dGP = 27.12825 * d2r, lCP = 122.93192 * d2r;
+    l *= d2r; b *= d2r;
+    const sinb = Math.sin(b), cosb = Math.cos(b);
+    const dec = Math.asin(Math.sin(dGP) * sinb + Math.cos(dGP) * cosb * Math.cos(lCP - l));
+    const y = cosb * Math.sin(lCP - l);
+    const x = Math.cos(dGP) * sinb - Math.sin(dGP) * cosb * Math.cos(lCP - l);
+    let ra = (aGP + Math.atan2(y, x)) / d2r;
+    ra = ((ra % 360) + 360) % 360;
+    return [ra, dec / d2r];
+}
+
+// Ecliptic (lon, lat) deg -> equatorial (RA, Dec) deg.
+function ecl2equ(lon, lat) {
+    const d2r = Math.PI / 180, eps = ECL_OBLIQUITY * d2r;
+    const l = lon * d2r, b = lat * d2r;
+    const dec = Math.asin(Math.sin(b) * Math.cos(eps) + Math.cos(b) * Math.sin(eps) * Math.sin(l));
+    const y = Math.sin(l) * Math.cos(eps) - Math.tan(b) * Math.sin(eps);
+    const x = Math.cos(l);
+    let ra = Math.atan2(y, x) / d2r;
+    ra = ((ra % 360) + 360) % 360;
+    return [ra, dec / d2r];
+}
+
+// SDSS survey great-circle coords (eta, lambda) deg -> equatorial (RA, Dec) deg.
+// Node = 95 deg, eta pole = 32.5 deg, matching idlutils etalambda_to_radec.
+function sdssEtaLambda2equ(eta, lambda) {
+    const d2r = Math.PI / 180, node = 95.0, etaPole = 32.5;
+    const l = lambda * d2r, e = (eta + etaPole) * d2r;
+    const x = -Math.sin(l);
+    const y = Math.cos(l) * Math.cos(e);
+    const z = Math.cos(l) * Math.sin(e);
+    let ra = Math.atan2(y, x) / d2r + node;
+    ra = ((ra % 360) + 360) % 360;
+    return [ra, Math.asin(z) / d2r];
+}
+
+// Equatorial (RA, Dec) -> galactic latitude b, deg.
+function equ2galLat(ra, dec) {
+    const d2r = Math.PI / 180, aGP = 192.85948 * d2r, dGP = 27.12825 * d2r;
+    ra *= d2r; dec *= d2r;
+    const sinb = Math.sin(dGP) * Math.sin(dec) + Math.cos(dGP) * Math.cos(dec) * Math.cos(ra - aGP);
+    return Math.asin(sinb) / d2r;
+}
+
+// Equatorial (RA, Dec) -> ecliptic latitude beta, deg.
+function equ2eclLat(ra, dec) {
+    const d2r = Math.PI / 180, eps = ECL_OBLIQUITY * d2r;
+    ra *= d2r; dec *= d2r;
+    const sinb = Math.sin(dec) * Math.cos(eps) - Math.cos(dec) * Math.sin(eps) * Math.sin(ra);
+    return Math.asin(sinb) / d2r;
+}
+
+// Subdivide polygon edges so they curve correctly through the projection.
+// Interpolates RA along the shortest direction so seam-wrapping edges behave.
+function densifyPolygon(vertices, stepDeg) {
+    const pts = [];
+    for (let i = 0; i < vertices.length - 1; i++) {
+        const a = vertices[i], b = vertices[i + 1];
+        const dRa = ((b[0] - a[0] + 540) % 360) - 180;
+        const dDec = b[1] - a[1];
+        const steps = Math.max(1, Math.ceil(Math.max(Math.abs(dRa), Math.abs(dDec)) / stepDeg));
+        for (let s = 0; s < steps; s++) {
+            const t = s / steps;
+            pts.push([a[0] + dRa * t, a[1] + dDec * t]);
+        }
+    }
+    pts.push(vertices[vertices.length - 1]);
+    return pts;
+}

--- a/sled_visualise/static/sled_visualise/footprints/des.js
+++ b/sled_visualise/static/sled_visualise/footprints/des.js
@@ -1,0 +1,25 @@
+// DES (Dark Energy Survey) wide footprint (~5000 deg^2, South Galactic Cap).
+// The real DR2/Y6 footprint is published only as a HEALPix mask; this is an
+// approximate closed [RA, Dec] polygon tracing the paper's "tank"-shaped outline
+// (arXiv 2101.05765): a wide quasi-rectangular far-south body (the SPT overlap,
+// ~Dec -40..-68), a rounded intermediate region, and the equatorial Stripe-82
+// extension (Dec ~ 0). It wraps across RA = 0 (spans RA ~ -54..+101), so with the
+// default map centring (RA = 0 at the left edge) it draws split between the two
+// map edges; the Map-centre toggle re-centres on RA = 0 to show it as one tank.
+// The last vertex repeats the first to close the polygon.
+window.SURVEY_FOOTPRINTS = window.SURVEY_FOOTPRINTS || {};
+
+const DES_FOOTPRINT = [
+    [-53, -55], [-43, -64], [-10, -68], [25, -67], [55, -60],
+    [78, -50], [93, -35], [99, -18], [101, -3], [93, 1],
+    [60, 3], [25, 4], [0, 4], [-25, 3], [-43, -2],
+    [-50, -20], [-54, -38], [-53, -55]
+];
+
+window.SURVEY_FOOTPRINTS.des = {
+    color: '#FF7B00',
+    style: { width: 2 },
+    build: function () {
+        return [densifyPolygon(DES_FOOTPRINT, 1.5)];
+    }
+};

--- a/sled_visualise/static/sled_visualise/footprints/euclid.js
+++ b/sled_visualise/static/sled_visualise/footprints/euclid.js
@@ -1,0 +1,40 @@
+// Euclid Wide Survey region of interest (Scaramella et al. 2022, A&A 662, A112).
+// The surveyed region is the EXTRA-galactic, EXTRA-ecliptic sky: |beta| >= 10 deg
+// (ecliptic; the paper's exact zodiacal-light limit) AND |b| >= ~25 deg (galactic;
+// the paper uses an E(B-V) dust contour relaxed from an original |b|>=20 cut, which
+// we approximate by a constant galactic-latitude cut). The boundary is therefore
+// made of ecliptic-cut arcs (kept only where the galactic cut is satisfied) and
+// galactic-cut arcs (kept only where the ecliptic cut is satisfied), giving the
+// characteristic two "mainlands" + two "islands" outline rather than four full
+// circles. The real mask is a HEALPix file; this is an approximate reconstruction.
+window.SURVEY_FOOTPRINTS = window.SURVEY_FOOTPRINTS || {};
+
+const EUCLID_ECL_CUT = 10;   // |ecliptic latitude| >= 10 deg (exact, per paper)
+const EUCLID_GAL_CUT = 25;   // |galactic latitude| >= ~25 deg (approx dust/density edge)
+
+function euclidBoundary() {
+    const segs = [];
+    for (const beta of [EUCLID_ECL_CUT, -EUCLID_ECL_CUT]) {
+        const seg = [];
+        for (let lon = 0; lon <= 360; lon++) {
+            const p = ecl2equ(lon, beta);
+            seg.push(Math.abs(equ2galLat(p[0], p[1])) >= EUCLID_GAL_CUT ? p : null);
+        }
+        segs.push(seg);
+    }
+    for (const b of [EUCLID_GAL_CUT, -EUCLID_GAL_CUT]) {
+        const seg = [];
+        for (let l = 0; l <= 360; l++) {
+            const p = gal2equ(l, b);
+            seg.push(Math.abs(equ2eclLat(p[0], p[1])) >= EUCLID_ECL_CUT ? p : null);
+        }
+        segs.push(seg);
+    }
+    return segs;
+}
+
+window.SURVEY_FOOTPRINTS.euclid = {
+    color: '#B26CFF',
+    style: { width: 2 },
+    build: euclidBoundary
+};

--- a/sled_visualise/static/sled_visualise/footprints/galactic.js
+++ b/sled_visualise/static/sled_visualise/footprints/galactic.js
@@ -1,0 +1,12 @@
+// Milky Way galactic plane (b = 0), drawn as a dashed great circle.
+window.SURVEY_FOOTPRINTS = window.SURVEY_FOOTPRINTS || {};
+
+window.SURVEY_FOOTPRINTS.galactic = {
+    color: '#FF4DA6',
+    style: { dashed: true, width: 1.5 },
+    build: function () {
+        const gp = [];
+        for (let l = 0; l <= 360; l++) gp.push(gal2equ(l, 0));
+        return [gp];
+    }
+};

--- a/sled_visualise/static/sled_visualise/footprints/sdss.js
+++ b/sled_visualise/static/sled_visualise/footprints/sdss.js
@@ -1,0 +1,47 @@
+// SDSS Legacy imaging footprint: the contiguous North Galactic Cap "lune" plus the
+// three South Galactic Cap scan stripes. Each is a rectangle in SDSS survey
+// (eta, lambda) coords transformed to RA/Dec. Bounds are approximate (the true
+// edges are ragged). The last vertex of each loop repeats the first to close it.
+window.SURVEY_FOOTPRINTS = window.SURVEY_FOOTPRINTS || {};
+
+// SGC imaging is three 2.5-deg-wide scan stripes (numbers 76, 82, 86). idlutils
+// maps stripe -> eta as eta = stripe*2.5 - 57.5 (minus 180 for stripe > 50):
+// stripe 82 -> eta -32.5 (= the celestial equator), 76 -> -47.5, 86 -> -22.5.
+// The SGC arc spans lambda ~125..234 (RA ~310 -> 59 through RA = 0).
+const SDSS_SGC_STRIPES = [-47.5, -32.5, -22.5]; // stripes 76, 82, 86
+const SDSS_SGC_LAM_MIN = 125, SDSS_SGC_LAM_MAX = 234, SDSS_STRIPE_HALF = 1.25;
+
+// Trace the contiguous NGC region as a rectangle in (eta, lambda): the
+// characteristic curved "lune". etaMin -32.5 = celestial equator (stripe 10);
+// etaMax 35 = stripe 37, the northern edge (~Dec +67 at the top of the lune).
+function sdssNgcBoundary() {
+    const lamMin = -63, lamMax = 63, etaMin = -33, etaMax = 35, step = 1;
+    const pts = [];
+    for (let lam = lamMin; lam <= lamMax; lam += step) pts.push(sdssEtaLambda2equ(etaMin, lam));
+    for (let eta = etaMin; eta <= etaMax; eta += step) pts.push(sdssEtaLambda2equ(eta, lamMax));
+    for (let lam = lamMax; lam >= lamMin; lam -= step) pts.push(sdssEtaLambda2equ(etaMax, lam));
+    for (let eta = etaMax; eta >= etaMin; eta -= step) pts.push(sdssEtaLambda2equ(eta, lamMin));
+    pts.push(pts[0]);
+    return pts;
+}
+
+// Trace one scan stripe as a closed constant-eta band (eta +/- half-width).
+function sdssStripe(etaC, lamMin, lamMax, half) {
+    const pts = [], step = 1;
+    for (let lam = lamMin; lam <= lamMax; lam += step) pts.push(sdssEtaLambda2equ(etaC - half, lam));
+    for (let lam = lamMax; lam >= lamMin; lam -= step) pts.push(sdssEtaLambda2equ(etaC + half, lam));
+    pts.push(pts[0]);
+    return pts;
+}
+
+window.SURVEY_FOOTPRINTS.sdss = {
+    color: '#F2C200',
+    style: { width: 2 },
+    build: function () {
+        const loops = [sdssNgcBoundary()];
+        for (const eta of SDSS_SGC_STRIPES) {
+            loops.push(sdssStripe(eta, SDSS_SGC_LAM_MIN, SDSS_SGC_LAM_MAX, SDSS_STRIPE_HALF));
+        }
+        return loops;
+    }
+};

--- a/sled_visualise/static/sled_visualise/js/lens_visualise.js
+++ b/sled_visualise/static/sled_visualise/js/lens_visualise.js
@@ -1,0 +1,708 @@
+const canvas = document.getElementById('skymap');
+const ctx = canvas.getContext('2d');
+const tooltip = document.getElementById('tooltip');
+const loading = document.getElementById('loading');
+const stats = document.getElementById('stats');
+
+let lensData = [];
+let transform = { scale: 1, offsetX: 0, offsetY: 0 };
+let isDragging = false;
+let lastMouseX = 0;
+let lastMouseY = 0;
+let hoveredPoint = null;
+let pinnedPoint = null;
+let isTooltipPinned = false;
+
+let config = {
+    pointSize: 4,
+    colorScheme: 'type',
+    showAxisLabels: false,
+    centerRA: 180,  // RA at the map center: 180 = RA=0 at the left edge; 0 = centered on RA=0
+    overlays: { des: false, sdss: false, euclid: false, galactic: false }
+};
+
+// Source-type colors (normalized buckets), chosen for visibility on the light map
+const sourceTypeColors = {
+    'Galaxy': '#E63946',
+    'Quasar': '#2A9D8F',
+    'Unknown': '#E9A100'
+};
+
+// Deflector-type colors are assigned dynamically from this palette (saturated
+// mid/dark tones that read clearly on the white map, led by the SLED brand purple)
+const lensTypePalette = ['#6F73DD','#E63946','#2A9D8F','#E9A100','#9C27B0','#1565C0','#2E7D32','#C2185B','#EF6C00','#5E35B1','#455A64'];
+const lensTypeColors = {};
+
+let redshiftChart = null;
+
+// Legend highlight filter (null = show all)
+let highlightFilter = null;
+
+function getSourceType(systemType) {
+    if (!systemType) return 'Unknown';
+    systemType = systemType.trim().toLowerCase();
+
+    if (systemType.includes('-')) {
+        const parts = systemType.split('-');
+        const sourceType = parts[parts.length - 1].trim();
+        if (sourceType.includes('qso') || sourceType.includes('quasar')) return 'Quasar';
+        if (sourceType.includes('gal') || sourceType.includes('galaxy')) return 'Galaxy';
+        if (sourceType.includes('star')) return 'Galaxy';
+    }
+    if (systemType.includes('qso') || systemType.includes('quasar')) return 'Quasar';
+    if (systemType.includes('gal') || systemType.includes('galaxy')) return 'Galaxy';
+    if (systemType.includes('cluster')) return 'Galaxy';
+    return 'Unknown';
+}
+
+function lensTypeLabel(point) {
+    return point.lens_type ? point.lens_type : 'Unknown';
+}
+
+function resizeCanvas() {
+    const container = document.getElementById('skymap-panel');
+    canvas.width = container.clientWidth - 30;
+    canvas.height = container.clientHeight - 30;
+    drawSkyMap();
+}
+
+// Aitoff projection (hardcoded — the only projection used)
+function project(ra, dec) {
+    const lambda = ((((ra - config.centerRA + 540) % 360) - 180) * Math.PI) / 180;
+    const phi = dec * Math.PI / 180;
+    const alpha = Math.acos(Math.cos(phi) * Math.cos(lambda / 2));
+    const sinc = alpha < 0.001 ? 1 : Math.sin(alpha) / alpha;
+    const x = 2 * Math.cos(phi) * Math.sin(lambda / 2) / sinc;
+    const y = Math.sin(phi) / sinc;
+    return { x, y };
+}
+
+function worldToScreen(x, y) {
+    const centerX = canvas.width / 2;
+    const centerY = canvas.height / 2;
+    const scale = Math.min(canvas.width, canvas.height) / 4.5 * transform.scale;
+    return {
+        x: centerX + x * scale + transform.offsetX,
+        y: centerY - y * scale + transform.offsetY
+    };
+}
+
+function getColorForPoint(point) {
+    if (config.colorScheme === 'type') {
+        return sourceTypeColors[point.source_type_norm] || sourceTypeColors['Unknown'];
+    } else if (config.colorScheme === 'lenstype') {
+        return lensTypeColors[lensTypeLabel(point)] || '#64b5f6';
+    } else if (config.colorScheme === 'source_z') {
+        const z = parseFloat(point.source_z) || 0;
+        const hue = Math.min(z / 5 * 240, 240);
+        return `hsl(${240 - hue}, 70%, 60%)`;
+    } else if (config.colorScheme === 'lens_z') {
+        const z = parseFloat(point.lens_z) || 0;
+        const hue = Math.min(z / 2 * 240, 240);
+        return `hsl(${240 - hue}, 70%, 60%)`;
+    }
+    return '#64b5f6';
+}
+
+function drawMarker(ctx, x, y, size, markerType) {
+    ctx.save();
+    if (markerType === 'Quasar') {
+        ctx.lineWidth = 2;
+        ctx.beginPath();
+        ctx.moveTo(x - size, y - size); ctx.lineTo(x + size, y + size);
+        ctx.moveTo(x + size, y - size); ctx.lineTo(x - size, y + size);
+        ctx.stroke();
+        ctx.beginPath();
+        ctx.moveTo(x - size, y); ctx.lineTo(x + size, y);
+        ctx.moveTo(x, y - size); ctx.lineTo(x, y + size);
+        ctx.stroke();
+    } else if (markerType === 'Galaxy') {
+        ctx.beginPath();
+        ctx.arc(x, y, size, 0, 2 * Math.PI);
+        ctx.fill();
+    } else {
+        ctx.beginPath();
+        ctx.arc(x, y, size, 0, 2 * Math.PI);
+        ctx.lineWidth = 2;
+        ctx.stroke();
+    }
+    ctx.restore();
+}
+
+function drawPoint(ctx, screenX, screenY, point) {
+    if (config.colorScheme === 'type') {
+        drawMarker(ctx, screenX, screenY, config.pointSize, point.source_type_norm);
+    } else {
+        ctx.beginPath();
+        ctx.arc(screenX, screenY, config.pointSize, 0, 2 * Math.PI);
+        ctx.fill();
+    }
+}
+
+// ---- Survey-footprint overlays ----
+// Each survey's geometry lives in its own file under static/sled_visualise/footprints/
+// (loaded before this script): galactic.js, euclid.js, des.js, sdss.js. Each self-
+// registers into the global SURVEY_FOOTPRINTS registry as { color, style, build() },
+// where build() returns an array of [RA, Dec] loops (a null entry marks an
+// intentional gap). Shared coordinate transforms and densifyPolygon live in
+// footprints/_coords.js. Draw order follows registry insertion order (= load order).
+
+// A jump in projected-x larger than this means the path crossed the RA=0/360
+// seam (left/right edge of the map) and the pen should lift rather than draw
+// a line straight across the whole map.
+const SEAM_THRESHOLD = 1.0;
+
+// Per-survey [RA, Dec] loop lists, built once from the registry's build() fns.
+const overlayGeom = {};
+function buildOverlayGeom() {
+    for (const key in SURVEY_FOOTPRINTS) {
+        overlayGeom[key] = SURVEY_FOOTPRINTS[key].build();
+    }
+}
+
+function strokeRaDecPolyline(pts, color, opts) {
+    opts = opts || {};
+    ctx.save();
+    ctx.strokeStyle = color;
+    ctx.lineWidth = opts.width || 2;
+    if (opts.dashed) ctx.setLineDash([6, 5]);
+    ctx.beginPath();
+    let prev = null, penUp = true;
+    for (let i = 0; i < pts.length; i++) {
+        // A null entry is an intentional gap (e.g. clipped Euclid boundary): lift the pen.
+        if (pts[i] === null) { penUp = true; prev = null; continue; }
+        // Normalize RA into [0,360) so wrapping footprints (negative RA / RA>360)
+        // stay within the projection's valid lambda range and don't shoot off-map.
+        const ra = ((pts[i][0] % 360) + 360) % 360;
+        const w = project(ra, pts[i][1]);
+        const s = worldToScreen(w.x, w.y);
+        if (prev && Math.abs(w.x - prev.x) > SEAM_THRESHOLD) penUp = true;
+        if (penUp) { ctx.moveTo(s.x, s.y); penUp = false; } else { ctx.lineTo(s.x, s.y); }
+        prev = w;
+    }
+    ctx.stroke();
+    ctx.restore();
+}
+
+function drawOverlays() {
+    for (const key in SURVEY_FOOTPRINTS) {
+        if (!config.overlays[key]) continue;
+        const fp = SURVEY_FOOTPRINTS[key];
+        (overlayGeom[key] || []).forEach(loop => strokeRaDecPolyline(loop, fp.color, fp.style));
+    }
+}
+
+function drawGrid() {
+    ctx.strokeStyle = 'rgba(0, 0, 0, 0.08)';
+    ctx.lineWidth = 1;
+
+    for (let ra = 0; ra <= 360; ra += 30) {
+        ctx.beginPath();
+        let first = true;
+        for (let dec = -90; dec <= 90; dec += 2) {
+            const s = worldToScreen(...Object.values(project(ra, dec)));
+            if (first) { ctx.moveTo(s.x, s.y); first = false; } else { ctx.lineTo(s.x, s.y); }
+        }
+        ctx.stroke();
+    }
+    for (let dec = -60; dec <= 60; dec += 30) {
+        ctx.beginPath();
+        let first = true;
+        for (let ra = 0; ra <= 360; ra += 2) {
+            const s = worldToScreen(...Object.values(project(ra, dec)));
+            if (first) { ctx.moveTo(s.x, s.y); first = false; } else { ctx.lineTo(s.x, s.y); }
+        }
+        ctx.stroke();
+    }
+
+    ctx.strokeStyle = 'rgba(111, 115, 221, 0.4)';
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    let first = true;
+    for (let ra = 0; ra <= 360; ra += 1) {
+        const s = worldToScreen(...Object.values(project(ra, 0)));
+        if (first) { ctx.moveTo(s.x, s.y); first = false; } else { ctx.lineTo(s.x, s.y); }
+    }
+    ctx.stroke();
+
+    if (config.showAxisLabels) {
+        ctx.font = "11px 'basic-sans', 'Segoe UI', sans-serif";
+        ctx.fillStyle = '#666';
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+        for (let ra = 0; ra <= 330; ra += 30) {
+            const s = worldToScreen(...Object.values(project(ra, 0)));
+            ctx.fillText(`${Math.round(ra / 15)}h`, s.x, s.y + 15);
+        }
+        for (let dec = -60; dec <= 60; dec += 30) {
+            if (dec === 0) continue;
+            const s = worldToScreen(...Object.values(project(config.centerRA, dec)));
+            ctx.fillText(dec > 0 ? `+${dec}°` : `${dec}°`, s.x - 20, s.y);
+        }
+        ctx.font = "12px 'basic-sans', 'Segoe UI', sans-serif";
+        ctx.fillStyle = '#6F73DD';
+        const raS = worldToScreen(...Object.values(project(config.centerRA, 0)));
+        ctx.fillText('RA', raS.x, raS.y + 35);
+        const decS = worldToScreen(...Object.values(project(config.centerRA, 0)));
+        ctx.save();
+        ctx.translate(decS.x - 45, decS.y);
+        ctx.rotate(-Math.PI / 2);
+        ctx.fillText('Dec', 0, 0);
+        ctx.restore();
+    }
+}
+
+function matchesHighlightFilter(point) {
+    if (!highlightFilter) return true;
+    if (config.colorScheme === 'type') return point.source_type_norm === highlightFilter;
+    if (config.colorScheme === 'lenstype') return lensTypeLabel(point) === highlightFilter;
+    return true;
+}
+
+// Trace the projection boundary (the all-sky ellipse): RA=0 down the left edge,
+// RA=360 down the right edge. Used to fill the map area white and outline it so
+// it reads as a defined plot panel against the light page.
+function drawBoundary() {
+    // The projection outline is the seam (lambda = +/-180), i.e. the meridian
+    // opposite the map center; trace just inside it on both sides.
+    const seam = (((config.centerRA + 180) % 360) + 360) % 360;
+    ctx.beginPath();
+    let first = true;
+    for (let dec = -90; dec <= 90; dec += 1) {
+        const s = worldToScreen(...Object.values(project(seam + 0.0001, dec)));
+        if (first) { ctx.moveTo(s.x, s.y); first = false; } else { ctx.lineTo(s.x, s.y); }
+    }
+    for (let dec = 90; dec >= -90; dec -= 1) {
+        const s = worldToScreen(...Object.values(project(seam - 0.0001, dec)));
+        ctx.lineTo(s.x, s.y);
+    }
+    ctx.closePath();
+    ctx.save();
+    ctx.fillStyle = '#ffffff';
+    ctx.fill();
+    ctx.strokeStyle = 'rgba(0, 0, 0, 0.25)';
+    ctx.lineWidth = 1.5;
+    ctx.stroke();
+    ctx.restore();
+}
+
+function drawSkyMap() {
+    ctx.fillStyle = '#ffffff';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    drawBoundary();
+    drawGrid();
+    drawOverlays();
+
+    if (highlightFilter) {
+        lensData.filter(p => !matchesHighlightFilter(p)).forEach(point => {
+            const s = worldToScreen(...Object.values(project(point.ra, point.dec)));
+            ctx.globalAlpha = 0.15;
+            const color = getColorForPoint(point);
+            ctx.fillStyle = color; ctx.strokeStyle = color;
+            drawPoint(ctx, s.x, s.y, point);
+            ctx.globalAlpha = 1.0;
+        });
+    }
+
+    const pointsToDraw = highlightFilter ? lensData.filter(matchesHighlightFilter) : lensData;
+    pointsToDraw.forEach(point => {
+        const s = worldToScreen(...Object.values(project(point.ra, point.dec)));
+        const color = getColorForPoint(point);
+        ctx.fillStyle = color; ctx.strokeStyle = color;
+        drawPoint(ctx, s.x, s.y, point);
+
+        if (hoveredPoint === point || pinnedPoint === point) {
+            ctx.strokeStyle = '#1a1a1a';
+            ctx.lineWidth = 2;
+            ctx.beginPath();
+            ctx.arc(s.x, s.y, config.pointSize + 3, 0, 2 * Math.PI);
+            ctx.stroke();
+        }
+    });
+
+    const shownCount = pointsToDraw.length;
+    const highlightText = highlightFilter ? ` | Highlighted: ${highlightFilter} (${shownCount})` : '';
+    stats.textContent = `Showing ${lensData.length} system${lensData.length === 1 ? '' : 's'}${highlightText}`;
+}
+
+function findPointAtMouse(mouseX, mouseY) {
+    const threshold = config.pointSize + 5;
+    const rect = canvas.getBoundingClientRect();
+    const cx = mouseX - rect.left;
+    const cy = mouseY - rect.top;
+    for (let point of lensData) {
+        const s = worldToScreen(...Object.values(project(point.ra, point.dec)));
+        const dx = s.x - cx;
+        const dy = s.y - cy;
+        if (Math.sqrt(dx * dx + dy * dy) < threshold) return point;
+    }
+    return null;
+}
+
+function infoRow(label, value) {
+    const row = document.createElement('div');
+    row.className = 'info-row';
+    const l = document.createElement('span');
+    l.className = 'info-label';
+    l.textContent = label;
+    const v = document.createElement('span');
+    v.className = 'info-value';
+    if (value instanceof Node) { v.appendChild(value); } else { v.textContent = value; }
+    row.appendChild(l);
+    row.appendChild(v);
+    return row;
+}
+
+function showTooltip(point, x, y) {
+    tooltip.innerHTML = '';
+
+    const close = document.createElement('button');
+    close.className = 'close-btn';
+    close.textContent = '×';
+    close.addEventListener('click', unpinTooltip);
+    tooltip.appendChild(close);
+
+    const h3 = document.createElement('h3');
+    h3.textContent = point.name || 'Unknown System';
+    tooltip.appendChild(h3);
+
+    tooltip.appendChild(infoRow('RA:', `${point.ra.toFixed(4)}°`));
+    tooltip.appendChild(infoRow('Dec:', `${point.dec.toFixed(4)}°`));
+    tooltip.appendChild(infoRow('Source Redshift:', point.source_z != null ? String(point.source_z) : 'N/A'));
+    tooltip.appendChild(infoRow('Deflector Redshift:', point.lens_z != null ? String(point.lens_z) : 'N/A'));
+    tooltip.appendChild(infoRow('Source Type:', point.source_type || 'N/A'));
+    tooltip.appendChild(infoRow('Deflector Type:', point.lens_type || 'N/A'));
+    tooltip.appendChild(infoRow('Flag:', point.flag || 'N/A'));
+
+    if (point.detail_url) {
+        const link = document.createElement('a');
+        link.href = point.detail_url;
+        link.target = '_blank';
+        link.textContent = 'View in SLED';
+        tooltip.appendChild(infoRow('Details:', link));
+    }
+
+    tooltip.style.display = 'block';
+    const rect = canvas.getBoundingClientRect();
+    tooltip.style.left = (rect.left + x + 15) + 'px';
+    tooltip.style.top = (rect.top + y + 15) + 'px';
+
+    const tr = tooltip.getBoundingClientRect();
+    if (tr.right > window.innerWidth) tooltip.style.left = (x - tr.width - 15) + 'px';
+    if (tr.bottom > window.innerHeight) tooltip.style.top = (y - tr.height - 15) + 'px';
+}
+
+function hideTooltip() {
+    if (!isTooltipPinned) tooltip.style.display = 'none';
+}
+
+function unpinTooltip() {
+    isTooltipPinned = false;
+    pinnedPoint = null;
+    tooltip.classList.remove('pinned');
+    tooltip.style.display = 'none';
+    drawSkyMap();
+}
+
+function handleLegendClick(category) {
+    highlightFilter = (highlightFilter === category) ? null : category;
+    updateColorbar();
+    drawSkyMap();
+}
+
+function makeLegendHeader(title) {
+    const h4 = document.createElement('h4');
+    h4.textContent = title + ' ';
+    const hint = document.createElement('span');
+    hint.className = 'legend-hint';
+    hint.textContent = '(click to highlight)';
+    h4.appendChild(hint);
+    return h4;
+}
+
+function makeMarkerLegendItem(category, label, drawFn) {
+    const item = document.createElement('div');
+    item.className = 'legend-item' + (highlightFilter === category ? ' active' : '');
+    const swatch = document.createElement('canvas');
+    swatch.width = 30; swatch.height = 30;
+    const span = document.createElement('span');
+    span.className = 'legend-label';
+    span.textContent = label;
+    item.appendChild(swatch);
+    item.appendChild(span);
+    item.addEventListener('click', () => handleLegendClick(category));
+    // draw swatch after it is in the DOM
+    const sctx = swatch.getContext('2d');
+    sctx.fillStyle = '#ffffff';
+    sctx.fillRect(0, 0, 30, 30);
+    drawFn(sctx);
+    return item;
+}
+
+function updateColorbar() {
+    const colorbar = document.getElementById('colorbar');
+    colorbar.innerHTML = '';
+
+    if (config.colorScheme === 'type') {
+        colorbar.appendChild(makeLegendHeader('Source Type'));
+        const list = document.createElement('div');
+        list.className = 'legend-list';
+        [['Quasar', 'Quasar'], ['Galaxy', 'Galaxy'], ['Unknown', 'Unknown']].forEach(([cat, label]) => {
+            list.appendChild(makeMarkerLegendItem(cat, label, (sctx) => {
+                const color = sourceTypeColors[cat];
+                sctx.fillStyle = color; sctx.strokeStyle = color;
+                drawMarker(sctx, 15, 15, 6, cat);
+            }));
+        });
+        colorbar.appendChild(list);
+
+    } else if (config.colorScheme === 'lenstype') {
+        colorbar.appendChild(makeLegendHeader('Deflector Type'));
+        const list = document.createElement('div');
+        list.className = 'legend-list';
+        const types = [...new Set(lensData.map(lensTypeLabel))].sort();
+        types.forEach(t => {
+            list.appendChild(makeMarkerLegendItem(t, t, (sctx) => {
+                const color = lensTypeColors[t] || '#64b5f6';
+                sctx.fillStyle = color;
+                sctx.beginPath();
+                sctx.arc(15, 15, 6, 0, 2 * Math.PI);
+                sctx.fill();
+            }));
+        });
+        colorbar.appendChild(list);
+
+    } else {
+        const h4 = document.createElement('h4');
+        h4.textContent = config.colorScheme === 'source_z' ? 'Source Redshift' : 'Deflector Redshift';
+        colorbar.appendChild(h4);
+        const grad = document.createElement('div');
+        grad.className = 'legend-gradient';
+        colorbar.appendChild(grad);
+        const labels = document.createElement('div');
+        labels.className = 'legend-labels';
+        const ends = config.colorScheme === 'source_z' ? ['0', '2.5', '5+'] : ['0', '1', '2+'];
+        ends.forEach(t => { const s = document.createElement('span'); s.textContent = t; labels.appendChild(s); });
+        colorbar.appendChild(labels);
+    }
+}
+
+function toggleInstructions() {
+    const instructions = document.getElementById('instructions');
+    const btn = instructions.querySelector('.toggle-btn');
+    if (instructions.classList.contains('collapsed')) {
+        instructions.classList.remove('collapsed');
+        btn.textContent = '−';
+    } else {
+        instructions.classList.add('collapsed');
+        btn.textContent = '+';
+    }
+}
+
+function toggleAxisLabels() {
+    config.showAxisLabels = !config.showAxisLabels;
+    const btn = document.getElementById('toggleAxisLabels');
+    btn.classList.toggle('active', config.showAxisLabels);
+    btn.textContent = config.showAxisLabels ? 'On' : 'Off';
+    drawSkyMap();
+}
+
+// Canvas interaction
+canvas.addEventListener('mousedown', (e) => {
+    const point = findPointAtMouse(e.clientX, e.clientY);
+    if (point) {
+        pinnedPoint = point;
+        isTooltipPinned = true;
+        tooltip.classList.add('pinned');
+        const rect = canvas.getBoundingClientRect();
+        showTooltip(point, e.clientX - rect.left, e.clientY - rect.top);
+        drawSkyMap();
+    } else {
+        isDragging = true;
+        lastMouseX = e.clientX;
+        lastMouseY = e.clientY;
+    }
+});
+
+canvas.addEventListener('mousemove', (e) => {
+    if (isDragging) {
+        transform.offsetX += e.clientX - lastMouseX;
+        transform.offsetY += e.clientY - lastMouseY;
+        lastMouseX = e.clientX;
+        lastMouseY = e.clientY;
+        drawSkyMap();
+    } else if (!isTooltipPinned) {
+        const point = findPointAtMouse(e.clientX, e.clientY);
+        if (point !== hoveredPoint) {
+            hoveredPoint = point;
+            drawSkyMap();
+            if (point) {
+                const rect = canvas.getBoundingClientRect();
+                showTooltip(point, e.clientX - rect.left, e.clientY - rect.top);
+            } else {
+                hideTooltip();
+            }
+        }
+    }
+});
+
+canvas.addEventListener('mouseup', () => { isDragging = false; });
+canvas.addEventListener('mouseleave', () => {
+    isDragging = false;
+    if (!isTooltipPinned) {
+        hoveredPoint = null;
+        hideTooltip();
+        drawSkyMap();
+    }
+});
+
+canvas.addEventListener('wheel', (e) => {
+    e.preventDefault();
+    const delta = e.deltaY > 0 ? 0.9 : 1.1;
+    transform.scale = Math.max(0.5, Math.min(transform.scale * delta, 5));
+    drawSkyMap();
+});
+
+document.getElementById('pointSize').addEventListener('input', (e) => {
+    config.pointSize = parseFloat(e.target.value);
+    document.getElementById('pointSizeValue').textContent = config.pointSize;
+    drawSkyMap();
+});
+
+document.getElementById('colorScheme').addEventListener('change', (e) => {
+    config.colorScheme = e.target.value;
+    highlightFilter = null;
+    updateColorbar();
+    drawSkyMap();
+    if (redshiftChart) createRedshiftChart();
+});
+
+[['overlayDES', 'des'], ['overlaySDSS', 'sdss'], ['overlayEuclid', 'euclid'], ['overlayGalactic', 'galactic']].forEach(([id, key]) => {
+    const btn = document.getElementById(id);
+    btn.addEventListener('click', () => {
+        config.overlays[key] = !config.overlays[key];
+        btn.classList.toggle('active', config.overlays[key]);
+        drawSkyMap();
+    });
+});
+
+document.getElementById('centerToggle').addEventListener('click', (e) => {
+    config.centerRA = config.centerRA === 180 ? 0 : 180;
+    e.currentTarget.classList.toggle('active', config.centerRA === 0);
+    drawSkyMap();
+});
+
+document.getElementById('toggleAxisLabels').addEventListener('click', toggleAxisLabels);
+document.getElementById('toggleInstructions').addEventListener('click', toggleInstructions);
+document.getElementById('resetRedshiftZoom').addEventListener('click', () => { if (redshiftChart) redshiftChart.resetZoom(); });
+document.getElementById('closeTooltip').addEventListener('click', unpinTooltip);
+window.addEventListener('resize', resizeCanvas);
+
+function createRedshiftChart() {
+    const rctx = document.getElementById('redshiftChart').getContext('2d');
+    const scatterData = lensData.map(point => ({
+        x: parseFloat(point.lens_z),
+        y: parseFloat(point.source_z),
+        point: point
+    })).filter(d => !isNaN(d.x) && !isNaN(d.y) && d.x > 0 && d.y > 0);
+
+    if (redshiftChart) redshiftChart.destroy();
+
+    redshiftChart = new Chart(rctx, {
+        type: 'scatter',
+        data: {
+            datasets: [
+                {
+                    type: 'line',
+                    label: '1:1 (z_source = z_deflector)',
+                    data: [{ x: 0, y: 0 }, { x: 10, y: 10 }],
+                    borderColor: 'rgba(63, 87, 101, 0.7)',
+                    borderDash: [6, 4],
+                    borderWidth: 1.5,
+                    pointRadius: 0,
+                    pointHoverRadius: 0,
+                    fill: false
+                },
+                {
+                    type: 'scatter',
+                    label: 'Lensing Systems',
+                    data: scatterData,
+                    backgroundColor: scatterData.map(d => getColorForPoint(d.point)),
+                    pointRadius: 3,
+                    pointHoverRadius: 5
+                }
+            ]
+        },
+        options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            animation: false,
+            layout: { padding: 5 },
+            scales: {
+                x: {
+                    type: 'linear', min: 0, max: 1.4,
+                    title: { display: true, text: 'z_deflector', color: '#333', font: { size: 11 } },
+                    ticks: { color: '#333', font: { size: 10 } },
+                    grid: { color: 'rgba(0, 0, 0, 0.08)' }
+                },
+                y: {
+                    type: 'linear', min: 0, max: 8.5,
+                    title: { display: true, text: 'z_source', color: '#333', font: { size: 11 } },
+                    ticks: { color: '#333', font: { size: 10 } },
+                    grid: { color: 'rgba(0, 0, 0, 0.08)' }
+                }
+            },
+            plugins: {
+                legend: { display: false },
+                tooltip: {
+                    filter: function(item) { return item.datasetIndex === 1; },
+                    callbacks: {
+                        label: function(context) {
+                            const p = context.raw.point;
+                            if (!p) return context.dataset.label;
+                            return [
+                                `System: ${p.name}`,
+                                `Deflector: ${p.lens_type || 'N/A'}`,
+                                `z_def: ${p.lens_z}`,
+                                `z_src: ${p.source_z}`
+                            ];
+                        }
+                    }
+                },
+                zoom: {
+                    pan: { enabled: true, mode: 'xy' },
+                    zoom: {
+                        wheel: { enabled: true },
+                        pinch: { enabled: true },
+                        drag: { enabled: true, backgroundColor: 'rgba(100, 181, 246, 0.2)', borderColor: 'rgba(100, 181, 246, 0.8)', borderWidth: 1 },
+                        mode: 'xy'
+                    },
+                    limits: { x: { min: 0, max: 2 }, y: { min: 0, max: 10 } }
+                }
+            }
+        }
+    });
+}
+
+function initData() {
+    const raw = JSON.parse(document.getElementById('lens-data').textContent);
+    lensData = raw.map(row => {
+        row.ra = parseFloat(row.ra);
+        row.dec = parseFloat(row.dec);
+        row.source_type_norm = getSourceType(row.system_type);
+        return row;
+    }).filter(p => !isNaN(p.ra) && !isNaN(p.dec));
+
+    // Assign a stable color to each deflector type present
+    [...new Set(lensData.map(lensTypeLabel))].sort().forEach((t, i) => {
+        lensTypeColors[t] = lensTypePalette[i % lensTypePalette.length];
+    });
+
+    buildOverlayGeom();
+    loading.style.display = 'none';
+    createRedshiftChart();
+    updateColorbar();
+    resizeCanvas();
+}
+
+initData();

--- a/sled_visualise/templates/sled_visualise/lens_visualise.html
+++ b/sled_visualise/templates/sled_visualise/lens_visualise.html
@@ -1,0 +1,116 @@
+{% load static %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Selected Gravitational Lenses — Interactive Sky Map</title>
+    <link rel="stylesheet" href="https://use.typekit.net/pkl4bli.css">
+    <link rel="stylesheet" href="{% static 'sled_visualise/css/lens_visualise.css' %}">
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/hammerjs@2.0.8"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-zoom@2.0.1/dist/chartjs-plugin-zoom.min.js"></script>
+</head>
+<body>
+    <div id="container">
+        <div id="header">
+            <img class="sled-logo" src="{% static 'images/JB_Master Header_Logo.png' %}" alt="SLED">
+            <div class="header-text">
+                <h1>Selected Gravitational Lenses — Interactive Sky Map</h1>
+                <p>Visualisation of the lenses you selected in the SLED query</p>
+            </div>
+        </div>
+
+        <div id="controls">
+            <div class="control-group">
+                <label for="pointSize">Point Size:</label>
+                <input type="range" id="pointSize" min="0.5" max="10" value="4" step="0.5">
+                <span id="pointSizeValue">4</span>
+            </div>
+
+            <div class="control-group">
+                <label for="colorScheme">Colour by:</label>
+                <select id="colorScheme">
+                    <option value="type">Source Type</option>
+                    <option value="lenstype">Deflector Type</option>
+                    <option value="source_z">Source Redshift</option>
+                    <option value="lens_z">Deflector Redshift</option>
+                </select>
+            </div>
+
+            <div class="control-group">
+                <label>RA/Dec Labels:</label>
+                <button id="toggleAxisLabels" class="ctrl-toggle-btn" title="Toggle RA/Dec labels">Off</button>
+            </div>
+
+            <div class="control-group">
+                <label>Map centre:</label>
+                <button id="centerToggle" class="ctrl-toggle-btn" title="Toggle map centre: off = RA=0 at the left edge; on = centred on RA=0">Centre on RA=0</button>
+            </div>
+
+            <div class="control-group">
+                <label>Overlays:</label>
+                <button id="overlayDES" class="ctrl-toggle-btn overlay-toggle" title="Toggle DES footprint (approximate)"><span class="ov-dot ov-des"></span>DES</button>
+                <button id="overlaySDSS" class="ctrl-toggle-btn overlay-toggle" title="Toggle SDSS footprint (approximate)"><span class="ov-dot ov-sdss"></span>SDSS</button>
+                <button id="overlayEuclid" class="ctrl-toggle-btn overlay-toggle" title="Toggle approximate Euclid Wide Survey region (|ecliptic latitude| > 10°, |galactic latitude| > 25°)"><span class="ov-dot ov-euclid"></span>Euclid</button>
+                <button id="overlayGalactic" class="ctrl-toggle-btn overlay-toggle" title="Toggle Milky Way galactic plane"><span class="ov-dot ov-galactic"></span>Galactic plane</button>
+            </div>
+        </div>
+
+        <div class="charts-container">
+            <!-- Left column: large sky map -->
+            <div class="chart-panel skymap-large" id="skymap-panel">
+                <div class="chart-title">All-Sky Map</div>
+                <canvas id="skymap"></canvas>
+                <div id="loading">
+                    <div class="spinner"></div>
+                    <div>Loading lens data...</div>
+                </div>
+                <div id="tooltip">
+                    <button class="close-btn" id="closeTooltip">×</button>
+                </div>
+                <div id="stats"></div>
+                <div id="instructions">
+                    <button class="toggle-btn" id="toggleInstructions">−</button>
+                    <h3>How to Use</h3>
+                    <h4 class="instr-subhead">Sky Map (center)</h4>
+                    <ul>
+                        <li><strong>Hover</strong> over any point to view system details</li>
+                        <li><strong>Scroll</strong> to zoom in/out, <strong>drag</strong> to pan</li>
+                        <li>Use <strong>controls</strong> to change point size, color scheme, and axis labels</li>
+                        <li><strong>Click</strong> a point to pin the tooltip (click × to close)</li>
+                        <li><strong>Click</strong> a legend item to highlight that subset</li>
+                        <li>Use <strong>Overlays</strong> to toggle approximate survey footprints (DES, SDSS, Euclid) and the Milky Way galactic plane</li>
+                    </ul>
+                    <h4 class="instr-subhead">Redshift Plot (left)</h4>
+                    <ul>
+                        <li><strong>Drag</strong> to select a region to zoom into</li>
+                        <li><strong>Pan</strong> by dragging when zoomed in</li>
+                        <li>Click <strong>"Reset"</strong> to restore the original view</li>
+                    </ul>
+                </div>
+            </div>
+
+            <!-- Right column: redshift scatter on top of the legend -->
+            <div class="info-column">
+                <div class="chart-panel redshift-panel">
+                    <div class="chart-title">z<sub>source</sub> vs z<sub>deflector</sub></div>
+                    <button id="resetRedshiftZoom" class="reset-zoom-btn" title="Reset zoom">Reset</button>
+                    <canvas id="redshiftChart"></canvas>
+                </div>
+                <div class="info-panel">
+                    <div id="colorbar"></div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    {{ lens_data|json_script:"lens-data" }}
+    <script src="{% static 'sled_visualise/footprints/_coords.js' %}"></script>
+    <script src="{% static 'sled_visualise/footprints/galactic.js' %}"></script>
+    <script src="{% static 'sled_visualise/footprints/euclid.js' %}"></script>
+    <script src="{% static 'sled_visualise/footprints/des.js' %}"></script>
+    <script src="{% static 'sled_visualise/footprints/sdss.js' %}"></script>
+    <script src="{% static 'sled_visualise/js/lens_visualise.js' %}"></script>
+</body>
+</html>

--- a/sled_visualise/tests.py
+++ b/sled_visualise/tests.py
@@ -1,0 +1,3 @@
+from django.test import TestCase
+
+# Create your tests here.

--- a/sled_visualise/urls.py
+++ b/sled_visualise/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+from . import views
+
+app_name = 'sled_visualise'
+urlpatterns = [
+    path('', views.LensVisualiseView.as_view(), name='lens-visualise'),
+]

--- a/sled_visualise/views.py
+++ b/sled_visualise/views.py
@@ -1,0 +1,63 @@
+from collections import defaultdict
+
+from django.shortcuts import render
+from django.urls import reverse
+from django.template.response import TemplateResponse
+from django.contrib.auth.decorators import login_required
+from django.views.generic import ListView
+from django.utils.decorators import method_decorator
+
+from lenses.models import Lenses, Redshift
+
+
+@method_decorator(login_required, name='dispatch')
+class LensVisualiseView(ListView):
+    model = Lenses
+    allow_empty = True
+    template_name = 'sled_visualise/lens_visualise.html'
+
+    def get_queryset(self, ids):
+        return Lenses.accessible_objects.in_ids(self.request.user, ids)
+
+    def build_data(self, lenses):
+        lens_ids = [lens.id for lens in lenses]
+
+        # Collect the first LENS and SOURCE redshift value per lens in a single query
+        z_by_lens = defaultdict(dict)
+        redshifts = Redshift.accessible_objects.all(self.request.user).filter(lens_id__in=lens_ids)
+        for z in redshifts:
+            if z.value is not None and z.tag not in z_by_lens[z.lens_id]:
+                z_by_lens[z.lens_id][z.tag] = float(z.value)
+
+        data = []
+        for lens in lenses:
+            lens_types = list(lens.lens_type) if lens.lens_type else []
+            source_types = list(lens.source_type) if lens.source_type else []
+            lt = lens_types[0] if lens_types else ''
+            st = source_types[0] if source_types else ''
+            data.append({
+                'id': lens.id,
+                'name': lens.name,
+                'ra': float(lens.ra),
+                'dec': float(lens.dec),
+                'lens_z': z_by_lens.get(lens.id, {}).get('LENS'),
+                'source_z': z_by_lens.get(lens.id, {}).get('SOURCE'),
+                'lens_type': lt,
+                'source_type': st,
+                'system_type': ('%s-%s' % (lt, st)) if (lt or st) else 'Unknown',
+                'flag': lens.flag,
+                'detail_url': reverse('lenses:lens-detail', args=[lens.id]),
+            })
+        return data
+
+    def post(self, request, *args, **kwargs):
+        ids = [pk for pk in self.request.POST.getlist('ids') if pk.isdigit()]
+        if ids:
+            lenses = self.get_queryset(ids)
+            context = {'lens_data': self.build_data(lenses)}
+            return render(request, self.template_name, context)
+        else:
+            return TemplateResponse(request, 'simple_message.html', context={'message': 'No selected lenses to visualise.'})
+
+    def get(self, request, *args, **kwargs):
+        return TemplateResponse(request, 'simple_message.html', context={'message': 'You are accessing this page in an unauthorized way.'})


### PR DESCRIPTION
New sled_visualise app: an interactive all-sky map of selected lenses (Aitoff projection, redshift scatter, survey/galactic overlays with a map-centre toggle). Adds a Visualise button on the query page and a query-all-ids endpoint so actions can target the full result set. I've also changed the "select all" button to select all targets across all pages. Lastly, I slightly modified a dev login-lockout fix so it would stop blocking my logins.

1. Visualise all-sky dashboard (new sled_visualise app)
A new self-contained Django app that opens an interactive all-sky map of the lenses selected on the query page. The dashboard is based on Courtney Watson's for the AGEL survey webpage page.

New "Visualise" button on lenses/query/, alongside See collage / Make collection / Export. It POSTs the checked lens IDs to the new view, which renders the dashboard in a new tab.

Sky map: HTML5-canvas Aitoff projection, colour-by source/deflector type or source/deflector redshift, point-size control, hover/click tooltips with a "View in SLED" link, pan/zoom.

Redshift scatter: z_source vs z_deflector with a dashed 1:1 reference line.

Survey/galactic overlays: toggleable reference outlines (SDSS Legacy, DES, Euclid Wide, Milky Way galactic plane). How the actual footprints need to be improved especially for DES. Each footprint lives in its own file under static/sled_visualise/footprints/ and self-registers into a small registry, so adding a survey is just a new file.

Map-centre toggle: flips the projection between RA=0 at the left edge (default) and RA=0 centred, so footprints straddling RA=0 (e.g. the DES tank) read as one connected region.

2. "Toggle select all" now spans all pages
Previously "Toggle select all" only checked the boxes on the current page (100/page). It now selects the entire query result list.

3. Dev login-lockout relaxation (settings_development.py)
For local development only, relaxes django-axes so testing isn't blocked by lockouts: AXES_COOLOFF_TIME = 0.25, AXES_FAILURE_LIMIT = 10, AXES_RESET_ON_SUCCESS = True.